### PR TITLE
use selective imports

### DIFF
--- a/src/hello.d
+++ b/src/hello.d
@@ -1,5 +1,4 @@
-import std.stdio;
-
 void main() {
+    import std.stdio: writeln;
     writeln("Hello World!");
 }


### PR DESCRIPTION
It's commonly known that selective imports reduce the compile time if that's what you want to go for.

Also the numbers on my machine are quite different (before this modification):

```
Dash         0:00:00.009000
Bash         0:00:00.009901
/bin/sh: tcc: command not found
Python2      0:00:00.021104
Python3      0:00:00.042348
GCC          0:00:00.147476
Go           0:00:00.505656
Rust         0:00:00.504069
RDMD         0:00:00.312133
Haskell      0:00:00.908211
DMD          0:00:00.223272
Java         0:00:00.789534
Scala        0:00:01.938681
```
